### PR TITLE
harden testing

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -147,9 +147,9 @@ pygments_dark_style = "monokai"
 
 # -- Options for HTML output -------------------------------------------------
 
-#html_theme = "alabaster"
+# html_theme = "alabaster"
 
-#html_theme_options = {"sidebar_width": "300px", "page_width": "1200px"}
+# html_theme_options = {"sidebar_width": "300px", "page_width": "1200px"}
 
 
 html_theme = "furo"
@@ -203,8 +203,8 @@ html_static_path = ["_static"]
 
 
 html_css_files = [
-     "custom.css",
- ]
+    "custom.css",
+]
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ appdirs
 configupdater
 packaging
 furo
-setuptools>=38.3
+setuptools>=58.3
 setuptools_scm
 sphinx>=3.2.1
 sphinx-copybutton

--- a/src/mud/__init__.py
+++ b/src/mud/__init__.py
@@ -2,9 +2,11 @@ import sys
 
 if sys.version_info[:2] >= (3, 8):
     # TODO: Import directly (no need for conditional) when `python_requires = >= 3.8`
-    from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
+    from importlib.metadata import (PackageNotFoundError,  # pragma: no cover
+                                    version)
 else:
-    from importlib_metadata import PackageNotFoundError, version  # pragma: no cover
+    from importlib_metadata import (PackageNotFoundError,  # pragma: no cover
+                                    version)
 
 try:
     # Change here if project is renamed and does not equal the package name

--- a/src/mud/base.py
+++ b/src/mud/base.py
@@ -1,7 +1,7 @@
 import numpy as np
 from scipy.stats import distributions as dist
 from scipy.stats import gaussian_kde as gkde
-
+from typing import Union, List
 
 class DensityProblem(object):
     """
@@ -46,12 +46,14 @@ class DensityProblem(object):
     def _n_samples(self):
         return self.y.shape[0]
 
-    def set_weights(self, weights=None):
+    def set_weights(self, weights: Union[np.ndarray, List] = None):
         if weights is not None:
             assert (
                 len(weights) == self._n_samples
             ), f"`weights` must size {self._n_samples}"
-            self._weights = weights
+            if isinstance(weights, list):
+                weights = np.array(weights)
+            self._weights = weights #/ weights.sum()
 
     def set_observed(self, distribution=dist.norm()):
         self._ob = distribution.pdf(self.y).prod(axis=1)
@@ -83,7 +85,8 @@ class DensityProblem(object):
         if weights is None:
             weights = self._weights
         else:  # TODO: log this to the user as INFO
-            self._weights = weights
+            self.set_weights(weights)
+        weights = self._weights
 
         if distribution is None:
             # Reweight kde of predicted by weights from previous iteration if present

--- a/src/mud/base.py
+++ b/src/mud/base.py
@@ -47,7 +47,7 @@ class DensityProblem(object):
     def _n_samples(self):
         return self.y.shape[0]
 
-    def set_weights(self, weights: Union[np.ndarray, List] = None):
+    def set_weights(self, weights: Union[np.ndarray, List]):
         if weights is not None:
             assert (
                 len(weights) == self._n_samples
@@ -94,10 +94,6 @@ class DensityProblem(object):
             distribution = gkde(self.y.T, bw_method=bw_method, weights=weights)
             pred_pdf_values = distribution.pdf(self.y.T).T
         else:
-            if (weights is not None) and ("weights" in dir(distribution)):
-                kwargs["weights"] = weights
-            if (bw_method is not None) and ("bw_method" in dir(distribution)):
-                kwargs["bw_method"] = bw_method
             pred_pdf_values = distribution.pdf(self.y, **kwargs)
 
         self._pr = pred_pdf_values

--- a/src/mud/base.py
+++ b/src/mud/base.py
@@ -19,7 +19,7 @@ class DensityProblem(object):
     >>> Y = np.repeat(X, num_obs, 1)
     >>> y = np.ones(num_obs)*0.5 + np.random.randn(num_obs)*0.05
     >>> W = wme(Y, y)
-    >>> B = DensityProblem(X, W, np.array([[0,1], [0,1]]))
+    >>> B = DensityProblem(X, W, np.array([[0,1]]))
     >>> np.round(B.mud_point()[0],1)
     0.5
 
@@ -72,11 +72,11 @@ class DensityProblem(object):
         if distribution is None:
             # Reweight kde of predicted by weights from previous iteration if present
             distribution = gkde(self.y.T, **kwargs)
-            pred_pdf = distribution.pdf(self.y.T).T
+            pred_pdf_values = distribution.pdf(self.y.T).T
         else:
-            pred_pdf = distribution.pdf(self.y, **kwargs)
+            pred_pdf_values = distribution.pdf(self.y, **kwargs)
 
-        self._pr = pred_pdf
+        self._pr = pred_pdf_values
         self._up = None
 
     def fit(self, **kwargs):
@@ -125,7 +125,7 @@ class BayesProblem(object):
     >>> num_obs = 50
     >>> Y = np.repeat(X, num_obs, 1)
     >>> y = np.ones(num_obs)*0.5 + np.random.randn(num_obs)*0.05
-    >>> B = BayesProblem(X, Y, np.array([[0,1], [0,1]]))
+    >>> B = BayesProblem(X, Y, np.array([[0,1]]))
     >>> B.set_likelihood(ds.norm(loc=y, scale=0.05))
     >>> np.round(B.map_point()[0],1)
     0.5

--- a/src/mud/base.py
+++ b/src/mud/base.py
@@ -1,7 +1,8 @@
+from typing import List, Union
+
 import numpy as np
 from scipy.stats import distributions as dist
 from scipy.stats import gaussian_kde as gkde
-from typing import Union, List
 
 
 class DensityProblem(object):

--- a/src/mud/base.py
+++ b/src/mud/base.py
@@ -3,6 +3,7 @@ from scipy.stats import distributions as dist
 from scipy.stats import gaussian_kde as gkde
 from typing import Union, List
 
+
 class DensityProblem(object):
     """
     Sets up Data-Consistent Inverse Problem for parameter identification
@@ -53,7 +54,7 @@ class DensityProblem(object):
             ), f"`weights` must size {self._n_samples}"
             if isinstance(weights, list):
                 weights = np.array(weights)
-            self._weights = weights #/ weights.sum()
+            self._weights = weights  # / weights.sum()
 
     def set_observed(self, distribution=dist.norm()):
         self._ob = distribution.pdf(self.y).prod(axis=1)

--- a/src/mud/funs.py
+++ b/src/mud/funs.py
@@ -5,13 +5,14 @@ Python console script for `mud`, installed with
 """
 
 import argparse
-import sys
 import logging
+import sys
+
 import numpy as np
+from scipy.stats import distributions as dists
 
 from mud import __version__
-from mud.base import DensityProblem, BayesProblem
-from scipy.stats import distributions as dists
+from mud.base import BayesProblem, DensityProblem
 
 __author__ = "Mathematical Michael"
 __copyright__ = "Mathematical Michael"

--- a/src/mud/plot.py
+++ b/src/mud/plot.py
@@ -1,5 +1,6 @@
-from matplotlib import pyplot as plt
 import numpy as np
+from matplotlib import pyplot as plt
+
 from mud.util import null_space
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ import numpy as np
 @pytest.fixture
 def problem_generator_identity_1D():
     def identity_uniform_1D(
-        num_samples=5000, num_obs=10, y_true=0.5, noise=0.05, weights=None
+        num_samples=2000, num_obs=10, y_true=0.5, noise=0.05, weights=None
     ):
         """
         Sets up an inverse problem using the unit domain and uniform distribution
@@ -68,18 +68,16 @@ def identity_problem_mud_1D_equal_weights(problem_generator_identity_1D):
     num_samples = 5000
     return problem_generator_identity_1D(
         num_samples=num_samples,
-        num_obs=10,
         weights=np.ones(num_samples),
     )
 
 
 @pytest.fixture
 def identity_problem_mud_1D_bias_weights(problem_generator_identity_1D):
-    num_samples = 1000
+    num_samples = 5000
     weights = np.ones(num_samples)
     D = problem_generator_identity_1D(
         num_samples=num_samples,
-        num_obs=10,
         weights=np.ones(num_samples),
     )
     weights[D.X[:, 0] < 0.2] = 0.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,14 @@ import numpy as np
 
 @pytest.fixture
 def problem_generator_identity_1D():
-    def identity_uniform_1D(num_samples, num_obs, y_true=0.5, noise=0.05, weights=None):
+    def identity_uniform_1D(
+        num_samples=5000, num_obs=10, y_true=0.5, noise=0.05, weights=None
+    ):
+        """
+        Sets up an inverse problem using the unit domain and uniform distribution
+        under an identity map. This is equivalent to studying a \"steady state\" signal over time,
+        or taking repeated measurements of the same quantity to reduce variance in the uncertainty.
+        """
         dist = ds.uniform(loc=0, scale=1)
         X = dist.rvs(size=(num_samples, 1))
         y_pred = np.repeat(X, num_obs, 1)
@@ -38,10 +45,7 @@ def problem_generator_identity_1D():
 
 @pytest.fixture
 def identity_problem_mud_1D(problem_generator_identity_1D):
-    return problem_generator_identity_1D(
-        num_samples=1000,
-        num_obs=10,
-    )
+    return problem_generator_identity_1D()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,8 +21,9 @@ def problem_generator_identity_1D():
     ):
         """
         Sets up an inverse problem using the unit domain and uniform distribution
-        under an identity map. This is equivalent to studying a \"steady state\" signal over time,
-        or taking repeated measurements of the same quantity to reduce variance in the uncertainty.
+        under an identity map. This is equivalent to studying a
+        \"steady state\" signal over time, or taking repeated measurements
+        of the same quantity to reduce variance in the uncertainty.
         """
         dist = ds.uniform(loc=0, scale=1)
         X = dist.rvs(size=(num_samples, 1))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,7 +65,7 @@ def identity_problem_map_1D():
 
 @pytest.fixture
 def identity_problem_mud_1D_equal_weights(problem_generator_identity_1D):
-    num_samples = 1000
+    num_samples = 5000
     return problem_generator_identity_1D(
         num_samples=num_samples,
         num_obs=10,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,11 +7,12 @@
     https://pytest.org/latest/plugins.html
 """
 
-import pytest
-from mud.base import DensityProblem, BayesProblem
-from mud.funs import wme
-from scipy.stats import distributions as ds
 import numpy as np
+import pytest
+from scipy.stats import distributions as ds
+
+from mud.base import BayesProblem, DensityProblem
+from mud.funs import wme
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,16 @@ import numpy as np
 
 
 @pytest.fixture
+def dist_wo_weights():
+    class Dist:
+        @classmethod
+        def pdf(self, x, **kwargs):
+            return []
+
+    return Dist
+
+
+@pytest.fixture
 def problem_generator_identity_1D():
     def identity_uniform_1D(
         num_samples=2000, num_obs=20, y_true=0.5, noise=0.05, weights=None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ import numpy as np
 @pytest.fixture
 def problem_generator_identity_1D():
     def identity_uniform_1D(
-        num_samples=2000, num_obs=10, y_true=0.5, noise=0.05, weights=None
+        num_samples=2000, num_obs=20, y_true=0.5, noise=0.05, weights=None
     ):
         """
         Sets up an inverse problem using the unit domain and uniform distribution

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -17,28 +17,56 @@ def test_identity_mud_problem_1D(identity_problem_mud_1D):
 
     # Assert
     assert np.round(mud_point, 1) == 0.5
-    assert np.abs(np.mean(ratio) - 1) < 0.1
+    assert np.abs(np.mean(ratio) - 1) < 0.2
 
 
 def test_we_can_set_weights_in_predicted(identity_problem_mud_1D_equal_weights):
-    """Mimicks existing usage in mud-examples"""
+    """
+    Mimicks existing usage in mud-examples.
+    We want to be able to pass a `weights` keyword to the `set_predicted` method
+    even if `weights` were passed during class initialization.
+
+    This test checks that the weights are saved correctly and that no error is raised
+    due to keyword handling.
+    """
     # Arrange
     # weights were used for initialization
     D = identity_problem_mud_1D_equal_weights
     D.set_initial()  # domain has been set -> uniform as default
-    # want to make sure we can set weights on predicted
-    weights = np.ones(D._n_samples)
-    D.set_predicted(weights=weights)
+    # want to make sure we can set weights on predicted and ensure they are saved.
+    weights = np.ones(D._n_samples)  #/ D._n_samples
 
     # Act
-    mud_point = D.estimate()
-    ratio = D._r
+    # also checking that `bw_method` can be passed to `gaussian_kde`
+    D.set_predicted(weights=weights, bw_method='scott')
 
     # Assert
-    # ensure weights were set correctly
+    # ensure weights were set correctly, we don't care about any other results here.
     assert np.linalg.norm(weights - D._weights) == 0
-    assert np.round(mud_point, 1) == 0.5
-    assert np.abs(np.mean(ratio) - 1) < 0.1
+
+
+def test_using_equal_weights_in_predicted_changes_nothing(identity_problem_mud_1D_equal_weights):
+    """
+    Ensures that the evaluation of predicted samples is equivalent when
+    passing weight vectors to `gaussian_kde` which assign equal weights to all samples.
+    """
+    # Arrange
+    # weights were used for initialization
+    D = identity_problem_mud_1D_equal_weights
+    D.set_initial()  # domain has been set -> uniform as default
+    # want to make sure we can set weights on predicted and ensure they are saved.
+    weights_ones = np.ones(D._n_samples)
+    weights_normalized = weights_ones / D._n_samples
+
+    # Act
+    D.set_predicted(weights=weights_ones)
+    predicted_ones = D._pr  # TODO: copy?
+    D.set_predicted(weights=weights_normalized)
+    predicted_normalized = D._pr
+
+    # Assert
+    # ensure weights do not impact evaluation of predicted density.
+    assert np.linalg.norm(predicted_ones - predicted_normalized) < 1E-14
 
 
 def test_identity_mud_1D_with_equal_weights(identity_problem_mud_1D_equal_weights):
@@ -47,13 +75,11 @@ def test_identity_mud_1D_with_equal_weights(identity_problem_mud_1D_equal_weight
 
     # Act
     mud_point = D.estimate()
-    updated_density = D._up
     ratio = D._r
 
     # Assert
     assert np.round(mud_point, 1) == 0.5
-    assert np.sum(updated_density) > 0
-    assert np.mean(ratio) > 0
+    assert np.abs(np.mean(ratio) - 1) < 0.2
 
 
 def test_identity_mud_1D_with_biased_weights(identity_problem_mud_1D_bias_weights):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -34,18 +34,20 @@ def test_we_can_set_weights_in_predicted(identity_problem_mud_1D_equal_weights):
     D = identity_problem_mud_1D_equal_weights
     D.set_initial()  # domain has been set -> uniform as default
     # want to make sure we can set weights on predicted and ensure they are saved.
-    weights = np.ones(D._n_samples)  #/ D._n_samples
+    weights = np.ones(D._n_samples)  # / D._n_samples
 
     # Act
     # also checking that `bw_method` can be passed to `gaussian_kde`
-    D.set_predicted(weights=weights, bw_method='scott')
+    D.set_predicted(weights=weights, bw_method="scott")
 
     # Assert
     # ensure weights were set correctly, we don't care about any other results here.
     assert np.linalg.norm(weights - D._weights) == 0
 
 
-def test_using_equal_weights_in_predicted_changes_nothing(identity_problem_mud_1D_equal_weights):
+def test_using_equal_weights_in_predicted_changes_nothing(
+    identity_problem_mud_1D_equal_weights,
+):
     """
     Ensures that the evaluation of predicted samples is equivalent when
     passing weight vectors to `gaussian_kde` which assign equal weights to all samples.
@@ -66,7 +68,7 @@ def test_using_equal_weights_in_predicted_changes_nothing(identity_problem_mud_1
 
     # Assert
     # ensure weights do not impact evaluation of predicted density.
-    assert np.linalg.norm(predicted_ones - predicted_normalized) < 1E-14
+    assert np.linalg.norm(predicted_ones - predicted_normalized) < 1e-14
 
 
 def test_identity_mud_1D_with_equal_weights(identity_problem_mud_1D_equal_weights):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
+from scipy.stats import distributions as ds
 
 __author__ = "Mathematical Michael"
 __copyright__ = "Mathematical Michael"
@@ -18,57 +19,6 @@ def test_identity_mud_problem_1D(identity_problem_mud_1D):
     # Assert
     assert np.round(mud_point, 1) == 0.5
     assert np.abs(np.mean(ratio) - 1) < 0.2
-
-
-def test_we_can_set_weights_in_predicted(identity_problem_mud_1D_equal_weights):
-    """
-    Mimicks existing usage in mud-examples.
-    We want to be able to pass a `weights` keyword to the `set_predicted` method
-    even if `weights` were passed during class initialization.
-
-    This test checks that the weights are saved correctly and that no error is raised
-    due to keyword handling.
-    """
-    # Arrange
-    # weights were used for initialization
-    D = identity_problem_mud_1D_equal_weights
-    D.set_initial()  # domain has been set -> uniform as default
-    # want to make sure we can set weights on predicted and ensure they are saved.
-    weights = np.random.rand(D._n_samples)
-
-    # Act
-    # also checking that `bw_method` can be passed to `gaussian_kde`
-    D.set_predicted(weights=weights, bw_method="scott")
-
-    # Assert
-    # ensure weights were set correctly, we don't care about any other results here.
-    assert np.linalg.norm(weights - D._weights) == 0
-
-
-def test_equal_weights_in_predicted_changes_nothing(
-    identity_problem_mud_1D_equal_weights,
-):
-    """
-    Ensures that the evaluation of predicted samples is equivalent when
-    passing weight vectors to `gaussian_kde` which assign equal weights to all samples.
-    """
-    # Arrange
-    # weights were used for initialization
-    D = identity_problem_mud_1D_equal_weights
-    D.set_initial()  # domain has been set -> uniform as default
-    # want to make sure we can set weights on predicted and ensure they are saved.
-    weights_ones = np.ones(D._n_samples)
-    weights_normalized = weights_ones / D._n_samples
-
-    # Act
-    D.set_predicted(weights=weights_ones)
-    predicted_ones = D._pr  # TODO: copy?
-    D.set_predicted(weights=weights_normalized)
-    predicted_normalized = D._pr
-
-    # Assert
-    # ensure weights do not impact evaluation of predicted density.
-    assert np.linalg.norm(predicted_ones - predicted_normalized) < 1e-14
 
 
 def test_identity_mud_1D_with_equal_weights(identity_problem_mud_1D_equal_weights):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-from scipy.stats import distributions as ds
 
 __author__ = "Mathematical Michael"
 __copyright__ = "Mathematical Michael"

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -45,7 +45,7 @@ def test_we_can_set_weights_in_predicted(identity_problem_mud_1D_equal_weights):
     assert np.linalg.norm(weights - D._weights) == 0
 
 
-def test_using_equal_weights_in_predicted_changes_nothing(
+def test_equal_weights_in_predicted_changes_nothing(
     identity_problem_mud_1D_equal_weights,
 ):
     """

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -18,8 +18,7 @@ def test_identity_mud_problem_1D(identity_problem_mud_1D):
 
     # Assert
     assert np.round(mud_point, 1) == 0.5
-    assert np.sum(updated_density) > 0
-    assert np.mean(ratio) > 0
+    assert np.abs(np.mean(ratio) - 1) < 0.1
 
 
 def test_we_can_set_weights_in_predicted(identity_problem_mud_1D_equal_weights):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -27,20 +27,18 @@ def test_we_can_set_weights_in_predicted(identity_problem_mud_1D_equal_weights):
     D = identity_problem_mud_1D_equal_weights
     D.set_initial()  # domain has been set -> uniform as default
     # want to make sure we can set weights on predicted
-    weights = np.random.rand(D._n_samples)
+    weights = np.ones(D._n_samples)
     D.set_predicted(weights=weights)
 
     # Act
     mud_point = D.estimate()
-    updated_density = D._up
     ratio = D._r
 
     # Assert
     # ensure weights were set correctly
     assert np.linalg.norm(weights - D._weights) == 0
     assert np.round(mud_point, 1) == 0.5
-    assert np.sum(updated_density) > 0
-    assert np.mean(ratio) > 0
+    assert np.abs(np.mean(ratio) - 1) < 0.1
 
 
 def test_identity_mud_1D_with_equal_weights(identity_problem_mud_1D_equal_weights):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -34,7 +34,7 @@ def test_we_can_set_weights_in_predicted(identity_problem_mud_1D_equal_weights):
     D = identity_problem_mud_1D_equal_weights
     D.set_initial()  # domain has been set -> uniform as default
     # want to make sure we can set weights on predicted and ensure they are saved.
-    weights = np.ones(D._n_samples)  # / D._n_samples
+    weights = np.random.rand(D._n_samples)
 
     # Act
     # also checking that `bw_method` can be passed to `gaussian_kde`

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -13,7 +13,6 @@ def test_identity_mud_problem_1D(identity_problem_mud_1D):
 
     # Act
     mud_point = D.estimate()
-    updated_density = D._up
     ratio = D._r
 
     # Assert

--- a/tests/test_funs.py
+++ b/tests/test_funs.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-import mud.funs as mdf
+
 import numpy as np
+
+import mud.funs as mdf
 
 __author__ = "Mathematical Michael"
 __copyright__ = "Mathematical Michael"

--- a/tests/test_funs.py
+++ b/tests/test_funs.py
@@ -35,13 +35,14 @@ class TestIdentityInitialCovariance(unittest.TestCase):
         err_map = sol_map - t
 
         # Assert
-        assert np.linalg.norm(err_mud) < 1e-8
-        assert np.linalg.norm(err_alt) < 1e-8
+        assert np.linalg.norm(err_mud) < 1e-6
+        assert np.linalg.norm(err_alt) < 1e-6
         assert np.linalg.norm(err_mud) < np.linalg.norm(err_map)
 
     def test_updated_cov_has_R_equal_zero_for_full_rank_A(self):
         up_cov = mdf.updated_cov(self.A, self.id, self.id)
-        assert np.linalg.norm(up_cov - np.linalg.inv(self.A.T @ self.A)) < 1e-6
+        absolute_error = np.linalg.norm(up_cov - np.linalg.inv(self.A.T @ self.A))
+        assert absolute_error / len(up_cov) < 1e-12
 
 
 class TestWME(unittest.TestCase):

--- a/tests/test_norm.py
+++ b/tests/test_norm.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-import mud.norm as mdn
+
 import numpy as np
+
+import mud.norm as mdn
 
 __author__ = "Mathematical Michael"
 __copyright__ = "Mathematical Michael"

--- a/tests/test_setting_predicted.py
+++ b/tests/test_setting_predicted.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+from scipy.stats import distributions as ds
+
+__author__ = "Mathematical Michael"
+__copyright__ = "Mathematical Michael"
+__license__ = "mit"
+
+
+def test_weights_in_predicted_with_no_distribution(problem_generator_identity_1D):
+    """
+    Mimicks existing usage in mud-examples.
+    We want to be able to pass a `weights` keyword to the `set_predicted` method
+    even if `weights` were passed during class initialization.
+
+    This test checks that the weights are saved correctly and that no error is raised
+    due to keyword handling.
+    """
+    # Arrange
+    # weights were used for initialization
+    # small sample size for speed
+    D = problem_generator_identity_1D(num_samples=100, weights=np.ones(100))
+    D.set_initial()  # domain has been set -> uniform as default
+    # want to make sure we can set weights on predicted and ensure they are saved.
+    weights = list(np.random.rand(D._n_samples))
+
+    # Act
+    # also checking that `bw_method` can be passed to `gaussian_kde`
+    D.set_predicted(weights=weights, bw_method="scott")
+
+    # Assert
+    # ensure weights were set correctly, we don't care about any other results here.
+    assert np.linalg.norm(weights - D._weights) == 0
+
+
+def test_weights_in_predicted_with_wrong_distribution(
+    problem_generator_identity_1D, dist_wo_weights
+):
+    """
+    Ensures that if we pass weights to a distribution that does not require them,
+    they are safely ignored but still saved.
+    """
+    # Arrange
+    # weights were used for initialization
+    # small sample size for speed
+    D = problem_generator_identity_1D(num_samples=100)
+
+    # want to make sure we can set weights on predicted and ensure they are saved.
+    weights = np.random.rand(D._n_samples)
+
+    # Act
+    D.set_predicted(distribution=dist_wo_weights, weights=weights)
+
+    # Assert
+    # ensure weights were set correctly, we don't care about any other results here.
+    assert np.linalg.norm(weights - D._weights) == 0
+    # dummy distribution returns empty list as pdf evaluation.
+    assert isinstance(D._pr, list) and len(D._pr) == 0
+
+
+def test_kwds_in_predicted_with_distribution(problem_generator_identity_1D):
+    """
+    Ensures that if we pass kwds to an unfrozen distribution that does requires them,
+    they are passed to the pdf function.
+    """
+    # Arrange
+    # small sample size for speed
+    D = problem_generator_identity_1D(num_samples=100)
+
+    # Act
+    D.set_predicted(distribution=ds.uniform, loc=100, scale=2)
+
+    # Assert
+    assert D._pr is not None
+    assert np.linalg.norm(D._pr) == 0  # no mutual support
+
+
+def test_equal_weights_in_predicted_changes_nothing(
+    identity_problem_mud_1D_equal_weights,
+):
+    """
+    Ensures that the evaluation of predicted samples is equivalent when
+    passing weight vectors to `gaussian_kde` which assign equal weights to all samples.
+    """
+    # Arrange
+    # weights were used for initialization
+    D = identity_problem_mud_1D_equal_weights
+    D.set_initial()  # domain has been set -> uniform as default
+    # want to make sure we can set weights on predicted and ensure they are saved.
+    weights_ones = np.ones(D._n_samples)
+    weights_normalized = weights_ones / D._n_samples
+
+    # Act
+    D.set_predicted(weights=weights_ones)
+    predicted_ones = D._pr  # TODO: copy?
+    D.set_predicted(weights=weights_normalized)
+    predicted_normalized = D._pr
+
+    # Assert
+    # ensure weights do not impact evaluation of predicted density.
+    assert np.linalg.norm(predicted_ones - predicted_normalized) < 1e-14

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+
 import mud.util as mdu
 
 __author__ = "Mathematical Michael"


### PR DESCRIPTION
now asserting on the predictability assumption / ratio diagnostic (checks that updated density would integrate to unity). tests tuned to take < 2s still but overall stable across reruns. tests usage expected in mud examples, makes sure weights are handled correctly.