### PR TITLE
tests failing: import

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     numpy>=1.20
     scipy
     matplotlib
-    sklearn
+    scikit-learn
 
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.7


### PR DESCRIPTION
https://github.com/mathematicalmichael/mud/actions/runs/3415251447/jobs/5684167616

what happened is this:

`sklearn-0.0.post1.tar.gz` was published and superceded `sklearn-0.0.tar.gz`, and due to the lack of pinning on `sklearn`, we pulled in the upgrade. this broke`import sklearn`.... very odd. very odd.

solution is just to pin to `scikit-learn` afaik.