### PR TITLE
specify dependency ranges

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     importlib-metadata; python_version<"3.10"
     numpy>=1.20
     scipy>=1.2,<2.0
-    matplotlib>=1.0.<4.0
+    matplotlib>=1.0,<4.0
     scikit-learn>=1.0,<2.0
 
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,8 +34,8 @@ install_requires =
     importlib-metadata; python_version<"3.10"
     numpy>=1.20
     scipy>=1.2,<2.0
-    matplotlib>=2.0.<4.0
-    scikit-learn>=1.1,<2.0
+    matplotlib>=1.0.<4.0
+    scikit-learn>=1.0,<2.0
 
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,9 +33,9 @@ package_dir =
 install_requires =
     importlib-metadata; python_version<"3.10"
     numpy>=1.20
-    scipy
-    matplotlib
-    scikit-learn
+    scipy>=1.2,<2.0
+    matplotlib>=3.0.<4.0
+    scikit-learn>=1.1,<2.0
 
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.7
@@ -67,7 +67,7 @@ examples =
     click
     tqdm
     prettytable
-    pandas
+    pandas>=1.2,<2.0
     wget
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ package_dir =
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 install_requires =
     importlib-metadata; python_version<"3.10"
-    numpy>=1.20
+    numpy>=1.20,<1.25
     scipy>=1.2,<2.0
     matplotlib>=1.0,<4.0
     scikit-learn>=1.0,<2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     importlib-metadata; python_version<"3.10"
     numpy>=1.20
     scipy>=1.2,<2.0
-    matplotlib>=3.0.<4.0
+    matplotlib>=2.0.<4.0
     scikit-learn>=1.1,<2.0
 
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4


### PR DESCRIPTION
I ended up trying to install mud on a computer with an older scikit-learn, and it ended up using the cache of like version 0.something, failed miserably to install...so I want to at least specify the major version we require for the more important libraries. these are _very loose_ pins on the dependencies.

I propose to publish as 0.1.1