### PR TITLE
make check for latex more robust

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,3 +94,32 @@ jobs:
 
       - name: New CLI
         run: mud examples mud-paper
+
+  texless-integration-tests:
+    name: texless cli examples
+    strategy:
+      matrix:
+        python-version: ["3.9"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Python dependencies
+        run: |
+          pip install --upgrade pip
+          pip install --upgrade mud-examples
+          pip install .[examples]
+
+      - name: Old CLI
+        run: mud_run_all -v
+
+      - name: New CLI
+        run: mud examples mud-paper

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,7 +119,9 @@ jobs:
           pip install .[examples]
 
       - name: Old CLI
+        continue-on-error: true
         run: mud_run_all -v
 
       - name: New CLI
+        continue-on-error: true
         run: mud examples mud-paper

--- a/src/mud/plot.py
+++ b/src/mud/plot.py
@@ -26,6 +26,7 @@ def _check_latex():
     path = Path.cwd() / ".test_fig.png"
     try:  # minimal example to trip up matplotlib
         plt.rcParams.update({"text.usetex": True})
+        plt.plot([0], [1], label=r"$a_\text{foo} = \lambda$")
         plt.plot([0, 1], [1, 2], label="Something")
         plt.savefig(str(path), bbox_inches="tight")
         path.unlink(missing_ok=True)

--- a/src/mud/plot.py
+++ b/src/mud/plot.py
@@ -8,6 +8,7 @@ Functions
 ---------
 
 """
+from logging import getLogger
 from pathlib import Path
 
 import numpy as np
@@ -15,7 +16,6 @@ from matplotlib import pyplot as plt  # type: ignore
 from scipy.stats.contingency import margins  # type: ignore
 
 from mud.util import null_space
-from logging import getLogger
 
 _logger = getLogger(__name__)
 

--- a/src/mud/plot.py
+++ b/src/mud/plot.py
@@ -15,8 +15,35 @@ from matplotlib import pyplot as plt  # type: ignore
 from scipy.stats.contingency import margins  # type: ignore
 
 from mud.util import null_space
+from logging import getLogger
+
+_logger = getLogger(__name__)
+
+
+def _check_latex():
+    """check latex installation"""
+
+    path = Path.cwd() / ".test_fig.png"
+    try:  # minimal example to trip up matplotlib
+        plt.rcParams.update({"text.usetex": True})
+        plt.plot([0, 1], [1, 2], label="Something")
+        plt.savefig(str(path), bbox_inches="tight")
+        path.unlink(missing_ok=True)
+        _logger.info("USING TEX")
+        return True
+    except (RuntimeError, FileNotFoundError):
+        _logger.warning("NOT USING TEX")
+        return False
+
 
 # Matplotlib plotting options
+HAS_LATEX = _check_latex()
+PREAMBLE = ""
+if HAS_LATEX:
+    PREAMBLE = " ".join(
+        [r"\usepackage{bm}", r"\usepackage{amsfonts}", r"\usepackage{amsmath}"]
+    )
+
 mud_plot_params = {
     "mathtext.fontset": "stix",
     "font.family": "STIXGeneral",
@@ -29,29 +56,10 @@ mud_plot_params = {
     "axes.labelpad": 1,
     "font.size": 16,
     "savefig.facecolor": "white",
-    "text.usetex": True,
-    "text.latex.preamble": " ".join(
-        [r"\usepackage{bm}", r"\usepackage{amsfonts}", r"\usepackage{amsmath}"]
-    ),
+    "text.usetex": HAS_LATEX,
+    "text.latex.preamble": PREAMBLE,
 }
 plt.rcParams.update(mud_plot_params)
-
-
-def _check_latex():
-    """check latex installation"""
-    global mud_plot_params
-
-    path = Path.cwd() / ".test_fig.png"
-    plt.plot([0], [1], label=r"$a_\text{foo} = \lambda$")
-    try:
-        plt.legend()
-        plt.savefig(str(path))
-        path.unlink(missing_ok=True)
-    except RuntimeError:
-        print("NOT USING TEX")
-        mud_plot_params["text.usetex"] = False
-        mud_plot_params["text.latex.preamble"] = ""
-        plt.rcParams.update(mud_plot_params)
 
 
 def save_figure(
@@ -227,6 +235,3 @@ def plot_vert_line(ax, x_loc, ylim=None, **kwargs):
     ylims[1] = ylim if ylim is not None else ylims[1]
     ax.plot([x_loc, x_loc], [ylims[0], ylims[1]], **kwargs)
     ax.set_ylim(ylims)
-
-
-_check_latex()


### PR DESCRIPTION
this simple change opens back up `mud-examples` to not solely relying on `0.0.28`, and should work with versions `0.1.1+`

to be fair, it was REALLY hard to figure out how to do this. Turns out a label _without_ TeX in it was what did the trick.